### PR TITLE
Add missing required in circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,8 @@ workflows:
           filters:
             branches:
               only: master
-            requires:
-            - build
+          requires:
+          - build
 
       - publish_to_stable:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,8 @@ workflows:
           filters:
             branches:
               only: master
+            requires:
+            - build
 
       - publish_to_stable:
           filters:


### PR DESCRIPTION
This got lost because there are no E2E tests but is needed because we try to deploy before having built otherwise.