### PR TITLE
Add service object for cluster-autoscaler

### DIFF
--- a/helm/kubernetes-cluster-autoscaler-chart/Chart.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the cluster autoscaler.
 name: kubernetes-cluster-autoscaler-chart
-version: 0.1.0-[[ .SHA ]]
+version: 0.2.0-[[ .SHA ]]

--- a/helm/kubernetes-cluster-autoscaler-chart/templates/service.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    giantswarm.io/service-type: "{{ .Values.serviceType }}"
+    app: {{ .Values.name }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: {{ .Values.name }}
+spec:
+  selector:
+    app: {{ .Values.name }}
+  ports:
+  - name: {{ .Values.ports.metrics.name }}
+    port: {{ .Values.ports.metrics.port }}
+    protocol: TCP

--- a/helm/kubernetes-cluster-autoscaler-chart/templates/service.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/templates/service.yaml
@@ -12,6 +12,6 @@ spec:
   selector:
     app: {{ .Values.name }}
   ports:
-  - name: {{ .Values.ports.metrics.name }}
-    port: {{ .Values.ports.metrics.port }}
+  - name: "metrics"
+    port: 8085
     protocol: TCP

--- a/helm/kubernetes-cluster-autoscaler-chart/values.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/values.yaml
@@ -10,8 +10,3 @@ image:
 
 cluster:
   id: "test-cluster"
-
-ports:
-  metrics:
-    name: metrics
-    port: 8085

--- a/helm/kubernetes-cluster-autoscaler-chart/values.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/values.yaml
@@ -10,3 +10,8 @@ image:
 
 cluster:
   id: "test-cluster"
+
+ports:
+  metrics:
+    name: metrics
+    port: 8085


### PR DESCRIPTION
In order to make prometheus-config-controller able to find cluster-autoscaler
PODs without major changes, it must have a service. It doesn't normally expose
any ports, but as service object requires at least one port definition, the
metrics port is used for this as that's the reason for the very existence of
this service object.