### PR TITLE
Change utilization threshold

### DIFF
--- a/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - --stderrthreshold=info
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
-            - --scale-down-utilization-threshold=0.65
+            - --scale-down-utilization-threshold={{ .Values.configmap.utilizationThreshold }}
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.cluster.id }}
           volumeMounts:
             - name: ssl-certs

--- a/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - --stderrthreshold=info
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
-            - --scale-down-utilization-threshold={{ .Values.configmap.utilizationThreshold }}
+            - --scale-down-utilization-threshold= {{ .Values.configmap.scaleDownUtilizationThreshold }}
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.cluster.id }}
           volumeMounts:
             - name: ssl-certs

--- a/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - --stderrthreshold=info
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
-            - --scale-down-utilization-threshold= {{ .Values.configmap.scaleDownUtilizationThreshold }}
+            - --scale-down-utilization-threshold={{ .Values.configmap.scaleDownUtilizationThreshold }}
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.cluster.id }}
           volumeMounts:
             - name: ssl-certs

--- a/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - --stderrthreshold=info
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
-            - --scale-down-utilization-threshold=0.6
+            - --scale-down-utilization-threshold=0.65
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.cluster.id }}
           volumeMounts:
             - name: ssl-certs

--- a/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
@@ -40,6 +40,7 @@ spec:
             - --stderrthreshold=info
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
+            - --scale-down-utilization-threshold=0.6
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/{{ .Values.cluster.id }}
           volumeMounts:
             - name: ssl-certs

--- a/helm/kubernetes-cluster-autoscaler-chart/values.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/values.yaml
@@ -2,7 +2,7 @@ name: cluster-autoscaler
 namespace: kube-system
 serviceType: managed
 
-# Make sure to update the docs at https://github.com/giantswarm/docs if you change the defaults below!
+# Make sure to update the docs at https://github.com/giantswarm/docs/blob/master/src/layouts/shortcodes/autoscaler_utilization_threshold.html if you change the defaults below
 configmap:
   scaleDownUtilizationThreshold: 0.65
 

--- a/helm/kubernetes-cluster-autoscaler-chart/values.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/values.yaml
@@ -4,7 +4,7 @@ serviceType: managed
 
 
 configmap:
-  utilizationThreshold: 0.65
+  scaleDownUtilizationThreshold: 0.65
 
 image:
   registry: quay.io

--- a/helm/kubernetes-cluster-autoscaler-chart/values.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/values.yaml
@@ -3,6 +3,9 @@ namespace: kube-system
 serviceType: managed
 
 
+configmap:
+  utilizationThreshold: 0.65
+
 image:
   registry: quay.io
   repository: giantswarm/cluster-autoscaler

--- a/helm/kubernetes-cluster-autoscaler-chart/values.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/values.yaml
@@ -2,7 +2,7 @@ name: cluster-autoscaler
 namespace: kube-system
 serviceType: managed
 
-
+# Make sure to update the docs at https://github.com/giantswarm/docs if you change the defaults below!
 configmap:
   scaleDownUtilizationThreshold: 0.65
 


### PR DESCRIPTION
This PR sets the default value for the utilization threshold lower and makes it configurable through the `user-data` configmap. This is necessary to allow us to scale down if the workload we create on an empty cluster is higher than 50%. This is already the case with `m5.large`.

Read more about the scale down process of autoscaler here:
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-scale-down-work

towards https://github.com/giantswarm/giantswarm/pull/2206