### PR TITLE
Update rbac for new autoscaler version

### DIFF
--- a/helm/kubernetes-cluster-autoscaler-chart/templates/rbac.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/templates/rbac.yaml
@@ -73,6 +73,7 @@ rules:
   resources:
   - statefulsets
   - replicasets
+  - daemonsets
   verbs:
   - watch
   - list
@@ -85,6 +86,16 @@ rules:
   - watch
   - list
   - get
+- apiGroups:
+  - batch
+  - extensions
+  resources:
+  - jobs
+  verbs:
+  - watch
+  - list
+  - get
+  - patch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/kubernetes-cluster-autoscaler-chart/templates/rbac.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/templates/rbac.yaml
@@ -113,6 +113,8 @@ rules:
   - configmaps
   verbs:
   - create
+  - list
+  - watch
 - apiGroups: [""]
   resources:
   - configmaps


### PR DESCRIPTION
The autoscaler was complaining in the latest version:
```
I0423 09:59:17.619773       1 reflector.go:161] Listing and watching *v1.Job from k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes/listers.go:339
E0423 09:59:17.622319       1 reflector.go:126] k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes/listers.go:339: Failed to list *v1.Job: jobs.batch is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list resource "jobs" in API group "batch" at the cluster scope
I0423 09:59:18.537481       1 reflector.go:161] Listing and watching *v1.DaemonSet from k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes/listers.go:319
E0423 09:59:18.539034       1 reflector.go:126] k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes/listers.go:319: Failed to list *v1.DaemonSet: daemonsets.apps is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list resource "daemonsets" in API group "apps" at the cluster scope
```

I oriented the RBAC rules on the official example:
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml