### PR TITLE
Backport RBAC to older release

### DIFF
--- a/helm/kubernetes-cluster-autoscaler-chart/Chart.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the cluster autoscaler.
 name: kubernetes-cluster-autoscaler-chart
-version: 0.3.0-[[ .SHA ]]
+version: 0.2.1-[[ .SHA ]]

--- a/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: "Exists"
-        key: node.kubernetes.io/master
+        key: node-role.kubernetes.io/master
       nodeSelector:
-        kubernetes.io/role: master
+        role: master
       containers:
         - image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           name: {{ .Values.name }}

--- a/helm/kubernetes-cluster-autoscaler-chart/values.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/values.yaml
@@ -9,7 +9,7 @@ configmap:
 image:
   registry: quay.io
   repository: giantswarm/cluster-autoscaler
-  tag: v1.14.0
+  tag: v1.13.1
 
 cluster:
   id: "test-cluster"


### PR DESCRIPTION
We have an issue that older releases of cluster-autoscaler (1.13.1 to be exact) suddenly require additional RBAC rules. This PR backports these new rules to version `0.2.1` which we can then ship to customers. The actual fix for the RBAC rules was made in a separate PR in `0.3.0` https://github.com/giantswarm/kubernetes-cluster-autoscaler/pull/16

Afterwards we revert this PR and move on as before.

Is this a valid way to handle this situation? Backporting seems a bit difficult otherwise.