### PR TITLE
Stay on k8s 1.13 for 0.3.0

### DIFF
--- a/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: "Exists"
-        key: node.kubernetes.io/master
+        key: node-role.kubernetes.io/master
       nodeSelector:
-        kubernetes.io/role: master
+        role: master
       containers:
         - image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           name: {{ .Values.name }}

--- a/helm/kubernetes-cluster-autoscaler-chart/values.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/values.yaml
@@ -9,7 +9,7 @@ configmap:
 image:
   registry: quay.io
   repository: giantswarm/cluster-autoscaler
-  tag: v1.14.0
+  tag: v1.13.1
 
 cluster:
   id: "test-cluster"


### PR DESCRIPTION
As previously discussed, we use `0.3.0` as a fix for k8s 1.13 instead of switching to 1.14.