### PR TITLE
Move 1.14 to 0.4.0 with correct labels

### DIFF
--- a/helm/kubernetes-cluster-autoscaler-chart/Chart.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for the cluster autoscaler.
 name: kubernetes-cluster-autoscaler-chart
-version: 0.3.0-[[ .SHA ]]
+version: 0.4.0-[[ .SHA ]]

--- a/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: "Exists"
-        key: node-role.kubernetes.io/master
+        key: node.kubernetes.io/master
       nodeSelector:
-        role: master
+        kubernetes.io/role: master
       containers:
         - image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           name: {{ .Values.name }}

--- a/helm/kubernetes-cluster-autoscaler-chart/values.yaml
+++ b/helm/kubernetes-cluster-autoscaler-chart/values.yaml
@@ -9,7 +9,7 @@ configmap:
 image:
   registry: quay.io
   repository: giantswarm/cluster-autoscaler
-  tag: v1.13.1
+  tag: v1.14.0
 
 cluster:
   id: "test-cluster"


### PR DESCRIPTION
Now `0.3.0` is k8s 1.13
And `0.4.0` is k8s 1.14